### PR TITLE
remove empty environment: from preview

### DIFF
--- a/charts/rpe-expressjs-template/values.preview.template.yaml
+++ b/charts/rpe-expressjs-template/values.preview.template.yaml
@@ -1,5 +1,4 @@
 nodejs:
-  environment:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}


### PR DESCRIPTION
`warning: cannot overwrite table with non table for environment` caused by using this empty environment:
This caused new environment vars from main values file toe not be set for preview.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
