### PR TITLE
Fix: bug loading main-dev.js file

### DIFF
--- a/src/main/views/webpack/js-template.njk
+++ b/src/main/views/webpack/js-template.njk
@@ -1,1 +1,1 @@
- <script src="<%= htmlWebpackPlugin.files.js[0].substr(htmlWebpackPlugin.files.publicPath.length) %>"></script>
+ <script src="/<%= htmlWebpackPlugin.files.js[0].substr(htmlWebpackPlugin.files.publicPath.length) %>"></script>


### PR DESCRIPTION
### Change description ###
When we run "yarn build" we are missing main-dev.js file because the src path is not correct.

Before, we were converting this (running the build):
`<script src="<%= htmlWebpackPlugin.files.js[0].substr(htmlWebpackPlugin.files.publicPath.length) %>"></script>`

To this:
`<script src="main-dev.js"></script>`

Now, when we run the build we are writing the correct path:
`<script src="/<%= htmlWebpackPlugin.files.js[0].substr(htmlWebpackPlugin.files.publicPath.length) %>"></script>`

To this:
`<script src="/main-dev.js"></script>`


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
