### PR TITLE
Info provider fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 
 !package.json
 !yarn.lock
+!version
 !.yarn/**
 !.yarnrc.yml
 !.pnp.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ src/main/views/govuk
 coverage/
 smoke-output/
 functional-output/
+version
 
 .eslintcache
 


### PR DESCRIPTION
Dockerfile needs to not exclude the info provider for it to actually provide version info.