### PR TITLE
Fix graceful shutdown

### DIFF
--- a/src/main/routes/health.ts
+++ b/src/main/routes/health.ts
@@ -1,12 +1,6 @@
-import { app as myApp } from '../app';
-
 import { Application } from 'express';
 
 const healthcheck = require('@hmcts/nodejs-healthcheck');
-
-function shutdownCheck(): boolean {
-  return myApp.locals.shutdown;
-}
 
 export default function (app: Application): void {
   const healthCheckConfig = {
@@ -15,9 +9,7 @@ export default function (app: Application): void {
       sampleCheck: healthcheck.raw(() => healthcheck.up()),
     },
     readinessChecks: {
-      shutdownCheck: healthcheck.raw(() => {
-        return shutdownCheck() ? healthcheck.down() : healthcheck.up();
-      }),
+      shutdownCheck: healthcheck.raw(() => healthcheck.up()),
     },
   };
 


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->

Follow up to a bug introduced in https://tools.hmcts.net/jira/browse/DTSPO-17277

### Change description

Previously this was completely broken, it only worked on the `https` server which is only used locally.
It also only stopped new requests after 4 seconds and then began closing them.

Shuts the server down so that new connections are no longer accepted by the server.
A hard shutdown of the server happens at 10 seconds now.

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

I implemented a route with a delay of 10 seconds and then 20 seconds before it responds.

```diff
+  app.get('/random10', (req, res) => {
+    setTimeout(() => {
+    res.render('home');
+  }, 10000)
+  });
+  app.get('/random20', (req, res) => {
+    setTimeout(() => {
+    res.render('home');
+  }, 20000)
+  });
```

The 10 second route shutdown cleanly with a 10 second delay roughly:
```
^C2024-09-10T14:53:35+01:00 - info: [server] ⚠️ Caught SIGINT, gracefully shutting down
2024-09-10T14:53:44+01:00 - info: [server] Connections closed, exiting
```

The 20 second route was forcefully shutdown:
```
^C2024-09-10T14:53:58+01:00 - info: [server] ⚠️ Caught SIGINT, gracefully shutting down
2024-09-10T14:54:08+01:00 - info: [server] Forcesfully shutting down application
```

With no open connections it shuts down immediately:
```
^C2024-09-10T15:03:52+01:00 - info: [server] ⚠️ Caught SIGINT, gracefully shutting down
2024-09-10T15:03:52+01:00 - info: [server] Connections closed, exiting
```

I reverted the healthcheck changes as when no more connections are allowed it never responded anyway:
```
curl localhost:3100/health/readiness
curl: (7) Failed to connect to localhost port 3100 after 0 ms: Couldn't connect to server
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
