### PR TITLE
Remove references to Jenkinsfile_CNP.disabled

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -14,7 +14,7 @@ read -p "Product name for new app (to replace rpe product references): " product
 read -p "Component name for new app (to replace rpe component references) : " component
 
 declare -a files_with_port=(Dockerfile README.md src/main/server.ts docker-compose.yml charts/rpe-expressjs-template/values.yaml src/test/config.ts src/test/smoke/smoke.ts)
-declare -a files_with_product=(package.json Jenkinsfile_CNP.disabled Jenkinsfile_nightly docker-compose.yml src/main/modules/properties-volume/index.ts src/main/modules/appinsights/index.ts charts/rpe-expressjs-template/Chart.yaml charts/rpe-expressjs-template/values.yaml Dockerfile README.md sonar-project.properties)
+declare -a files_with_product=(package.json Jenkinsfile_CNP Jenkinsfile_nightly docker-compose.yml src/main/modules/properties-volume/index.ts src/main/modules/appinsights/index.ts charts/rpe-expressjs-template/Chart.yaml charts/rpe-expressjs-template/values.yaml Dockerfile README.md sonar-project.properties)
 
 # Replace port number
 for i in ${files_with_port[@]}
@@ -31,9 +31,6 @@ done
 
 # Rename directory to provided package name
 git mv charts/rpe-expressjs-template/ charts/${product}-${component}
-
-# Rename CNP file
-git mv Jenkinsfile_CNP.disabled Jenkinsfile_CNP
 
 declare -a headers_to_delete=("Purpose" "What's inside" "Setup" )
 


### PR DESCRIPTION
### Change description

The `./bin/init.sh` script fails with the following error message:

_Can't open Jenkinsfile_CNP.disabled: No such file or directory._

The script has been fixed by referencing **Jenkinsfile_CNP** rather than **Jenkinsfile_CNP.disabled** as the latter is no longer used.

### Testing done

Executed ./bin/init.sh to confirm the script executes without error and correctly updates Jenkinsfile_CNP with the product and component values supplied by the user.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
